### PR TITLE
Add a consumer which uses nsqlookupd to find nsqd instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ A connection string looks like this:
 
 ### Consuming Messages
 
-    var cons = new NsqConsumer("nsqd=server1:4150");
-    await cons.ConnectAsync("my-topic", "my-channel", (t, c, byte[] msg) =>
+    var cons = NsqConsumer.Create("nsqd=server1:4150; topic=my-topic; channel=my-channel");
+    await cons.ConnectAndWaitAsync(Handler);
 
     static async Task Handler(Message message, IMessageFinalizer finalizer)
     {
@@ -45,14 +45,14 @@ A connection string looks like this:
 
 Or, to use nsqlookupd:
 
-    nsqlookupd=lookup1:4161,lookup2:4161;
+    lookup1:4161; lookup2:4161;
 
-A connection string must specify _either_ `nsqd` endpoints _or_ `nsqlookupd` endpoints, but not both.
+A connection string must specify _either_ an `nsqd` endpoint _or_ `nsqlookupd` endpoints, but not both.
 
 | Setting               | Description                                                                                           |
 | --------------------- | ----------------------------------------------------------------------------------------------------- |
-| nsqd={endpoints}      | List of `nsqd` servers in the form `hostname:tcpport`, e.g., `server1:4150,server2:4150`              |
-| lookupd={endpoints}   | List of `nsqlookupd` servers in the form `hostname:httpport`, e.g., `lookup1:4161,lookup2:4161`       |
+| lookupd={endpoints}   | List of `nsqlookupd` servers in the form `hostname:httpport`, e.g., `lookup1:4161;lookup2:4161`       |
+| nsqd={endpoints}      | A _single_ `nsqd` servers in the form `hostname:tcpport`, e.g., `nsqd=server1:4150;nsqd=server2:4150` |
 | clientId={string}     | A string identifying this client to the `nsqd` server                                                 |
 | hostname={string}     | The hostname to identify as (defaults to Environment.MachineName)                                     |
 | maxInFlight={int}     | The maximum number of messages this client wants to receive without completion                        |

--- a/src/TestClient/ConsumerForm.cs
+++ b/src/TestClient/ConsumerForm.cs
@@ -39,12 +39,13 @@ namespace TestClient
             var options = ConsumerOptions.Parse(string.Format("nsqd={0}:{1}", host, port));
             options.Topic = TopicTextBox.Text;
             options.Channel = ChannelTextBox.Text;
-            _nsq = NsqTcpConnection.Connect(new DnsEndPoint(host, port), options, async msg =>
+            _nsq = new NsqTcpConnection(new DnsEndPoint(host, port), options);
+            _nsq.InternalMessages += _nsq_InternalMessages;
+            _nsq.Connect(async msg =>
             {
                 await c_MessageReceived(msg);
                 await msg.FinishAsync();
             });
-            _nsq.InternalMessages += _nsq_InternalMessages;
 
         }
 

--- a/src/TestClient/LookupConsumerForm.Designer.cs
+++ b/src/TestClient/LookupConsumerForm.Designer.cs
@@ -1,0 +1,185 @@
+﻿namespace TestClient
+{
+    partial class LookupConsumerForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.ConnectButton = new System.Windows.Forms.Button();
+            this.ReceivedMessages = new System.Windows.Forms.ListBox();
+            this.DisconnectButton = new System.Windows.Forms.Button();
+            this.ReadyButton = new System.Windows.Forms.Button();
+            this.ReadyTextBox = new System.Windows.Forms.TextBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.ConnectionString = new System.Windows.Forms.TextBox();
+            this.DiscoveredEndPoints = new System.Windows.Forms.ListBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.LastDiscoveryTime = new System.Windows.Forms.TextBox();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(8, 14);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(132, 20);
+            this.label1.TabIndex = 6;
+            this.label1.Text = "ConnectionString";
+            // 
+            // ConnectButton
+            // 
+            this.ConnectButton.Location = new System.Drawing.Point(360, 69);
+            this.ConnectButton.Name = "ConnectButton";
+            this.ConnectButton.Size = new System.Drawing.Size(134, 49);
+            this.ConnectButton.TabIndex = 9;
+            this.ConnectButton.Text = "Connect";
+            this.ConnectButton.UseVisualStyleBackColor = true;
+            this.ConnectButton.Click += new System.EventHandler(this.ConnectButton_Click);
+            // 
+            // ReceivedMessages
+            // 
+            this.ReceivedMessages.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.ReceivedMessages.FormattingEnabled = true;
+            this.ReceivedMessages.ItemHeight = 20;
+            this.ReceivedMessages.Location = new System.Drawing.Point(12, 196);
+            this.ReceivedMessages.Name = "ReceivedMessages";
+            this.ReceivedMessages.Size = new System.Drawing.Size(622, 424);
+            this.ReceivedMessages.TabIndex = 10;
+            // 
+            // DisconnectButton
+            // 
+            this.DisconnectButton.Location = new System.Drawing.Point(500, 69);
+            this.DisconnectButton.Name = "DisconnectButton";
+            this.DisconnectButton.Size = new System.Drawing.Size(134, 49);
+            this.DisconnectButton.TabIndex = 11;
+            this.DisconnectButton.Text = "Close";
+            this.DisconnectButton.UseVisualStyleBackColor = true;
+            this.DisconnectButton.Click += new System.EventHandler(this.DisconnectButton_Click);
+            // 
+            // ReadyButton
+            // 
+            this.ReadyButton.Location = new System.Drawing.Point(500, 141);
+            this.ReadyButton.Name = "ReadyButton";
+            this.ReadyButton.Size = new System.Drawing.Size(134, 49);
+            this.ReadyButton.TabIndex = 17;
+            this.ReadyButton.Text = "Ready";
+            this.ReadyButton.UseVisualStyleBackColor = true;
+            this.ReadyButton.Click += new System.EventHandler(this.ReadyButton_Click);
+            // 
+            // ReadyTextBox
+            // 
+            this.ReadyTextBox.Font = new System.Drawing.Font("Consolas", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.ReadyTextBox.Location = new System.Drawing.Point(360, 164);
+            this.ReadyTextBox.Name = "ReadyTextBox";
+            this.ReadyTextBox.Size = new System.Drawing.Size(134, 26);
+            this.ReadyTextBox.TabIndex = 18;
+            this.ReadyTextBox.Text = "100";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(356, 141);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(55, 20);
+            this.label5.TabIndex = 19;
+            this.label5.Text = "Ready";
+            // 
+            // ConnectionString
+            // 
+            this.ConnectionString.Location = new System.Drawing.Point(12, 37);
+            this.ConnectionString.Name = "ConnectionString";
+            this.ConnectionString.Size = new System.Drawing.Size(622, 26);
+            this.ConnectionString.TabIndex = 20;
+            // 
+            // DiscoveredEndPoints
+            // 
+            this.DiscoveredEndPoints.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.DiscoveredEndPoints.FormattingEnabled = true;
+            this.DiscoveredEndPoints.ItemHeight = 20;
+            this.DiscoveredEndPoints.Location = new System.Drawing.Point(640, 196);
+            this.DiscoveredEndPoints.Name = "DiscoveredEndPoints";
+            this.DiscoveredEndPoints.Size = new System.Drawing.Size(221, 424);
+            this.DiscoveredEndPoints.TabIndex = 21;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(640, 141);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(112, 20);
+            this.label2.TabIndex = 23;
+            this.label2.Text = "Last Discovery";
+            // 
+            // LastDiscoveryTime
+            // 
+            this.LastDiscoveryTime.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.LastDiscoveryTime.Location = new System.Drawing.Point(640, 164);
+            this.LastDiscoveryTime.Name = "LastDiscoveryTime";
+            this.LastDiscoveryTime.Size = new System.Drawing.Size(221, 26);
+            this.LastDiscoveryTime.TabIndex = 24;
+            // 
+            // LookupConsumerForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(873, 653);
+            this.Controls.Add(this.LastDiscoveryTime);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.DiscoveredEndPoints);
+            this.Controls.Add(this.ConnectionString);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.ReadyTextBox);
+            this.Controls.Add(this.ReadyButton);
+            this.Controls.Add(this.DisconnectButton);
+            this.Controls.Add(this.ReceivedMessages);
+            this.Controls.Add(this.ConnectButton);
+            this.Controls.Add(this.label1);
+            this.Name = "LookupConsumerForm";
+            this.Text = "ConsumerForm";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ConsumerForm_FormClosing);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button ConnectButton;
+        private System.Windows.Forms.ListBox ReceivedMessages;
+        private System.Windows.Forms.Button DisconnectButton;
+        private System.Windows.Forms.Button ReadyButton;
+        private System.Windows.Forms.TextBox ReadyTextBox;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.TextBox ConnectionString;
+        private System.Windows.Forms.ListBox DiscoveredEndPoints;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox LastDiscoveryTime;
+    }
+}

--- a/src/TestClient/LookupConsumerForm.cs
+++ b/src/TestClient/LookupConsumerForm.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Turbocharged.NSQ;
+
+namespace TestClient
+{
+    public partial class LookupConsumerForm : Form
+    {
+        BindingList<string> _messages = new BindingList<string>();
+        BindingList<string> _endPoints = new BindingList<string>();
+        NsqLookupConsumer _nsq;
+
+        public LookupConsumerForm(string connectionString)
+        {
+            InitializeComponent();
+            ConnectionString.Text = connectionString;
+            ReceivedMessages.DataSource = _messages;
+            DiscoveredEndPoints.DataSource = _endPoints;
+        }
+
+        void _nsq_DiscoveryCompleted(object s, DiscoveryEventArgs e)
+        {
+            if (InvokeRequired)
+            {
+                Invoke((Action<object, DiscoveryEventArgs>)_nsq_DiscoveryCompleted, s, e);
+            }
+            else
+            {
+                _endPoints.Clear();
+                foreach (var address in e.NsqAddresses)
+                {
+                    _endPoints.Add(address.BroadcastAddress + ":" + address.TcpPort);
+                }
+
+                LastDiscoveryTime.Text = DateTime.Now.ToString("T");
+            }
+        }
+
+        void _nsq_InternalMessages(object s, InternalMessageEventArgs e)
+        {
+            PostMessage("INTERNAL: " + e.Message);
+        }
+
+        void ConnectButton_Click(object sender, EventArgs e)
+        {
+            var connectionString = ConnectionString.Text;
+            var options = ConsumerOptions.Parse(connectionString);
+
+            _nsq = NsqLookupConsumer.Connect(options, async msg =>
+            {
+                await c_MessageReceived(msg);
+                await msg.FinishAsync();
+            });
+            _nsq.DiscoveryCompleted += _nsq_DiscoveryCompleted;
+            _nsq.InternalMessages += _nsq_InternalMessages;
+        }
+
+        Task c_MessageReceived(Turbocharged.NSQ.Message obj)
+        {
+            var data = BitConverter.ToString(obj.Body, 0);
+            var message = string.Format("RECEIVED MESSAGE. Id = {0}, Msg = {1}", obj.Id, data);
+            PostMessage(message);
+            return Task.FromResult(0);
+        }
+
+        void ConsumerForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (_nsq != null)
+                _nsq.Dispose();
+        }
+
+        void PostMessage(string obj)
+        {
+            var threadId = Thread.CurrentThread.ManagedThreadId;
+            Invoke((Action)(() =>
+            {
+                _messages.Add(obj + " (ThreadId = " + threadId + ")");
+                ReceivedMessages.SelectedIndex = ReceivedMessages.Items.Count - 1;
+            }));
+        }
+
+        void DisconnectButton_Click(object sender, EventArgs e)
+        {
+            _nsq.Dispose();
+        }
+
+        async void ReadyButton_Click(object sender, EventArgs e)
+        {
+            var maxInFlight = int.Parse(ReadyTextBox.Text);
+            await _nsq.SetMaxInFlightAsync(maxInFlight);
+        }
+    }
+}

--- a/src/TestClient/LookupConsumerForm.cs
+++ b/src/TestClient/LookupConsumerForm.cs
@@ -55,13 +55,14 @@ namespace TestClient
             var connectionString = ConnectionString.Text;
             var options = ConsumerOptions.Parse(connectionString);
 
-            _nsq = NsqLookupConsumer.Connect(options, async msg =>
+            _nsq = new NsqLookupConsumer(options);
+            _nsq.DiscoveryCompleted += _nsq_DiscoveryCompleted;
+            _nsq.InternalMessages += _nsq_InternalMessages;
+            _nsq.Connect(async msg =>
             {
                 await c_MessageReceived(msg);
                 await msg.FinishAsync();
             });
-            _nsq.DiscoveryCompleted += _nsq_DiscoveryCompleted;
-            _nsq.InternalMessages += _nsq_InternalMessages;
         }
 
         Task c_MessageReceived(Turbocharged.NSQ.Message obj)

--- a/src/TestClient/LookupConsumerForm.resx
+++ b/src/TestClient/LookupConsumerForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/TestClient/MainForm.Designer.cs
+++ b/src/TestClient/MainForm.Designer.cs
@@ -31,6 +31,7 @@
             this.button1 = new System.Windows.Forms.Button();
             this.button2 = new System.Windows.Forms.Button();
             this.button3 = new System.Windows.Forms.Button();
+            this.button4 = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // button1
@@ -63,11 +64,22 @@
             this.button3.UseVisualStyleBackColor = true;
             this.button3.Click += new System.EventHandler(this.button3_Click);
             // 
+            // button4
+            // 
+            this.button4.Location = new System.Drawing.Point(741, 12);
+            this.button4.Name = "button4";
+            this.button4.Size = new System.Drawing.Size(237, 69);
+            this.button4.TabIndex = 3;
+            this.button4.Text = "New Lookup Consumer";
+            this.button4.UseVisualStyleBackColor = true;
+            this.button4.Click += new System.EventHandler(this.button4_Click);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(750, 95);
+            this.ClientSize = new System.Drawing.Size(991, 95);
+            this.Controls.Add(this.button4);
             this.Controls.Add(this.button3);
             this.Controls.Add(this.button2);
             this.Controls.Add(this.button1);
@@ -82,6 +94,7 @@
         private System.Windows.Forms.Button button1;
         private System.Windows.Forms.Button button2;
         private System.Windows.Forms.Button button3;
+        private System.Windows.Forms.Button button4;
     }
 }
 

--- a/src/TestClient/MainForm.cs
+++ b/src/TestClient/MainForm.cs
@@ -53,5 +53,13 @@ namespace TestClient
             form.Show();
             form.Activate();
         }
+
+        void button4_Click(object sender, EventArgs e)
+        {
+            var connectionString = string.Format("{0}:{1}; topic={2}; channel={3}", lookupHostName, lookupPort, "foo", "bar");
+            var form = new LookupConsumerForm(connectionString);
+            form.Show();
+            form.Activate();
+        }
     }
 }

--- a/src/TestClient/TestClient.csproj
+++ b/src/TestClient/TestClient.csproj
@@ -44,6 +44,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LookupConsumerForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="LookupConsumerForm.Designer.cs">
+      <DependentUpon>LookupConsumerForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="ConsumerForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -70,6 +76,9 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <EmbeddedResource Include="LookupConsumerForm.resx">
+      <DependentUpon>LookupConsumerForm.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="ConsumerForm.resx">
       <DependentUpon>ConsumerForm.cs</DependentUpon>
     </EmbeddedResource>

--- a/src/Turbocharged.NSQ.Tests/ConsumerOptionFacts.cs
+++ b/src/Turbocharged.NSQ.Tests/ConsumerOptionFacts.cs
@@ -25,12 +25,11 @@ namespace Turbocharged.NSQ.Tests
         [Fact]
         public void ParsingGetsAllFields()
         {
-            var connectionString = "foo:123; channel=abc; clientId=def; hostname=ghi; maxInFlight=123; reconnectionDelay=55; reconnectionMaxDelay=66; topic=foobar";
+            var connectionString = "foo:123; channel=abc; clientId=def; hostname=ghi; reconnectionDelay=55; reconnectionMaxDelay=66; topic=foobar";
             var options = ConsumerOptions.Parse(connectionString);
             Assert.Equal("abc", options.Channel);
             Assert.Equal("def", options.ClientId);
             Assert.Equal("ghi", options.HostName);
-            Assert.Equal(123, options.MaxInFlight);
             Assert.Equal(TimeSpan.FromSeconds(55), options.ReconnectionDelay);
             Assert.Equal(TimeSpan.FromSeconds(66), options.ReconnectionMaxDelay);
             Assert.Equal("foobar", options.Topic);

--- a/src/Turbocharged.NSQ.Tests/NsqLookupConsumerFacts.cs
+++ b/src/Turbocharged.NSQ.Tests/NsqLookupConsumerFacts.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Turbocharged.NSQ.Tests
+{
+    public class NsqLookupConsumerFacts
+    {
+        DnsEndPoint lookupEndPoint;
+        ConsumerOptions options;
+        NsqProducer prod;
+
+        public NsqLookupConsumerFacts()
+        {
+            lookupEndPoint = new DnsEndPoint(Settings.LookupHostName, Settings.LookupPort);
+            options = new ConsumerOptions
+            {
+                LookupEndPoints = { lookupEndPoint }
+            };
+            prod = new NsqProducer(Settings.NsqdHostName, Settings.NsqdHttpPort);
+        }
+
+        [Fact]
+        public async Task CanConnectViaLookupConnection()
+        {
+            options.Topic = "foo";
+            options.Channel = "bar";
+            var tcs = new TaskCompletionSource<bool>();
+            using (var consumer = await NsqLookupConsumer.ConnectAndWaitAsync(options, msg =>
+            {
+                tcs.TrySetResult(true);
+                return msg.FinishAsync();
+            }))
+            {
+                consumer.InternalMessages += OutputMessage;
+                await Task.WhenAll(
+                    consumer.SetMaxInFlightAsync(100),
+                    consumer.WriteAsync("hello"));
+                var task = tcs.Task;
+                var done = await Task.WhenAny(task, Task.Delay(1000));
+                Assert.Same(task, done);
+            }
+        }
+
+        void OutputMessage(object sender, InternalMessageEventArgs e)
+        {
+            System.Diagnostics.Debug.WriteLine(e.Message);
+        }
+    }
+}

--- a/src/Turbocharged.NSQ.Tests/NsqLookupConsumerFacts.cs
+++ b/src/Turbocharged.NSQ.Tests/NsqLookupConsumerFacts.cs
@@ -31,13 +31,15 @@ namespace Turbocharged.NSQ.Tests
             options.Topic = "foo";
             options.Channel = "bar";
             var tcs = new TaskCompletionSource<bool>();
-            using (var consumer = await NsqLookupConsumer.ConnectAndWaitAsync(options, msg =>
-            {
-                tcs.TrySetResult(true);
-                return msg.FinishAsync();
-            }))
+            using (var consumer = new NsqLookupConsumer(options))
             {
                 consumer.InternalMessages += OutputMessage;
+                await consumer.ConnectAndWaitAsync(msg =>
+                {
+                    tcs.TrySetResult(true);
+                    return msg.FinishAsync();
+                });
+
                 await Task.WhenAll(
                     consumer.SetMaxInFlightAsync(100),
                     consumer.WriteAsync("hello"));

--- a/src/Turbocharged.NSQ.Tests/NsqProducerFacts.cs
+++ b/src/Turbocharged.NSQ.Tests/NsqProducerFacts.cs
@@ -53,7 +53,8 @@ namespace Turbocharged.NSQ.Tests
 
             // Now try to receive anything
             bool receivedData = false;
-            conn = NsqTcpConnection.Connect(endPoint, options, async msg =>
+            conn = new NsqTcpConnection(endPoint, options);
+            await conn.ConnectAndWaitAsync(async msg =>
             {
                 receivedData = true;
                 await msg.FinishAsync();

--- a/src/Turbocharged.NSQ.Tests/Settings.cs
+++ b/src/Turbocharged.NSQ.Tests/Settings.cs
@@ -35,5 +35,23 @@ namespace Turbocharged.NSQ.Tests
                 return int.Parse(httpPortStr ?? ConfigurationManager.AppSettings["NSQ.HttpPort"]);
             }
         }
+
+        public static string LookupHostName
+        {
+            get
+            {
+                var hostname = Environment.GetEnvironmentVariable("NSQLOOKUPD_HOSTNAME");
+                return hostname ?? ConfigurationManager.AppSettings["Lookup.Hostname"];
+            }
+        }
+
+        public static int LookupPort
+        {
+            get
+            {
+                var tcpPortStr = Environment.GetEnvironmentVariable("NSQLOOKUPD_TCP_PORT");
+                return int.Parse(tcpPortStr ?? ConfigurationManager.AppSettings["Lookup.Port"]);
+            }
+        }
     }
 }

--- a/src/Turbocharged.NSQ.Tests/TcpConnectionFacts.cs
+++ b/src/Turbocharged.NSQ.Tests/TcpConnectionFacts.cs
@@ -34,6 +34,16 @@ namespace Turbocharged.NSQ.Tests
         #endregion
 
         [Fact]
+        public void ConsumerFactoryReturnsNsqTcpConnectionWhenNsqdEndPointIsGiven()
+        {
+            options.NsqEndPoint = endPoint;
+            using (var conn = NsqConsumer.Connect(options, msg => msg.FinishAsync()))
+            {
+                Assert.IsType<NsqTcpConnection>(conn);
+            }
+        }
+
+        [Fact]
         public void ConnectionClosesProperly()
         {
             options.Topic = "foo";

--- a/src/Turbocharged.NSQ.Tests/TcpConnectionFacts.cs
+++ b/src/Turbocharged.NSQ.Tests/TcpConnectionFacts.cs
@@ -39,8 +39,10 @@ namespace Turbocharged.NSQ.Tests
             options.Topic = "foo";
             options.Channel = "bar";
             var tcs = new TaskCompletionSource<bool>();
-            using (var conn = await NsqTcpConnection.ConnectAndWaitAsync(endPoint, options, msg => { tcs.TrySetResult(true); return msg.FinishAsync(); }))
+            using (var conn = new NsqTcpConnection(endPoint, options))
             {
+                Assert.False(conn.Connected);
+                await conn.ConnectAndWaitAsync(msg => { tcs.TrySetResult(true); return msg.FinishAsync(); });
                 Assert.True(conn.Connected);
 
                 // Just for kicks, verify we're working
@@ -57,19 +59,20 @@ namespace Turbocharged.NSQ.Tests
         public void ConsumerFactoryReturnsNsqTcpConnectionWhenNsqdEndPointIsGiven()
         {
             options.NsqEndPoint = endPoint;
-            using (var conn = NsqConsumer.Connect(options, msg => msg.FinishAsync()))
+            using (var conn = NsqConsumer.Create(options))
             {
                 Assert.IsType<NsqTcpConnection>(conn);
             }
         }
 
         [Fact]
-        public void ConnectionClosesProperly()
+        public async Task ConnectionClosesProperly()
         {
             options.Topic = "foo";
             options.Channel = "bar";
-            var conn = NsqTcpConnection.Connect(endPoint, options, msg => msg.FinishAsync());
+            var conn = new NsqTcpConnection(endPoint, options);
             conn.InternalMessages += (_, e) => Trace.WriteLine(e.Message);
+            await conn.ConnectAndWaitAsync(msg => msg.FinishAsync());
             conn.Dispose();
         }
 
@@ -84,15 +87,17 @@ namespace Turbocharged.NSQ.Tests
 
             var tcs = new TaskCompletionSource<Message>();
             var task = tcs.Task;
-            var conn = NsqTcpConnection.Connect(endPoint, options, async msg =>
-            {
-                await msg.FinishAsync();
-                tcs.TrySetResult(msg);
-            });
-            conn.InternalMessages += (_, e) => Trace.WriteLine(e.Message);
+            var conn = new NsqTcpConnection(endPoint, options);
 
             using (conn)
             {
+                conn.InternalMessages += (_, e) => Trace.WriteLine(e.Message);
+                await conn.ConnectAndWaitAsync(async msg =>
+                {
+                    await msg.FinishAsync();
+                    tcs.TrySetResult(msg);
+                });
+
                 await conn.SetMaxInFlightAsync(100);
                 await prod.PublishAsync(options.Topic, expectedData);
                 await Task.WhenAny(task, Task.Delay(1000));
@@ -113,15 +118,16 @@ namespace Turbocharged.NSQ.Tests
             await EmptyChannelAsync(options.Topic, options.Channel);
 
             int messagesReceived = 0;
-            var conn = NsqTcpConnection.Connect(endPoint, options, async msg =>
-            {
-                await msg.FinishAsync().ConfigureAwait(false);
-                Interlocked.Increment(ref messagesReceived);
-            });
-            conn.InternalMessages += (_, e) => Trace.WriteLine(e.Message);
+            var conn = new NsqTcpConnection(endPoint, options);
 
             using (conn)
             {
+                conn.InternalMessages += (_, e) => Trace.WriteLine(e.Message);
+                await conn.ConnectAndWaitAsync(async msg =>
+                {
+                    await msg.FinishAsync().ConfigureAwait(false);
+                    Interlocked.Increment(ref messagesReceived);
+                });
                 await conn.SetMaxInFlightAsync(100);
                 var messages = Enumerable.Range(0, 1000).Select(i => (MessageBody)BitConverter.GetBytes(i)).ToArray();
                 await prod.PublishAsync(options.Topic, messages);

--- a/src/Turbocharged.NSQ.Tests/Turbocharged.NSQ.Tests.csproj
+++ b/src/Turbocharged.NSQ.Tests/Turbocharged.NSQ.Tests.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="ConsumerOptionFacts.cs" />
     <Compile Include="MessageConversionFacts.cs" />
+    <Compile Include="NsqLookupConsumerFacts.cs" />
     <Compile Include="NsqProducerFacts.cs" />
     <Compile Include="TcpConnectionFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Turbocharged.NSQ/Addresses.cs
+++ b/src/Turbocharged.NSQ/Addresses.cs
@@ -9,30 +9,79 @@ namespace Turbocharged.NSQ
     /// <summary>
     /// The address of an nsqlookupd instance.
     /// </summary>
-    public class LookupAddress
+    public struct LookupAddress : IEquatable<LookupAddress>
     {
-        public string HostName { get; set; }
-        public int HttpPort { get; set; }
+        public string HostName { get; private set; }
+        public int HttpPort { get; private set; }
+
+        public LookupAddress(string hostName, int httpPort)
+            : this()
+        {
+            HostName = hostName;
+            HttpPort = httpPort;
+        }
 
         public override string ToString()
         {
             return "HostName = " + HostName + ", HttpPort = " + HttpPort;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LookupAddress)
+                return Equals((LookupAddress)obj);
+
+            return false;
+        }
+
+        /// <summary>
+        /// The address of an nsqd instance.
+        /// </summary>
+        public bool Equals(LookupAddress other)
+        {
+            return HttpPort == other.HttpPort
+                && string.Equals(HostName, other.HostName, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 
     /// <summary>
     /// The address of an nsqd instance.
     /// </summary>
-    public class NsqAddress
+    public struct NsqAddress : IEquatable<NsqAddress>
     {
-        public string BroadcastAddress { get; set; }
-        public string HostName { get; set; }
-        public int HttpPort { get; set; }
-        public int TcpPort { get; set; }
+        public string BroadcastAddress { get; private set; }
+        public string HostName { get; private set; }
+        public int HttpPort { get; private set; }
+        public int TcpPort { get; private set; }
+
+        public NsqAddress(string broadcastAddress, string hostName, int tcpPort, int httpPort)
+            : this()
+        {
+            BroadcastAddress = broadcastAddress;
+            HostName = hostName;
+            TcpPort = tcpPort;
+            HttpPort = httpPort;
+        }
 
         public override string ToString()
         {
             return "BroadcastAddress = " + BroadcastAddress + ", TcpPort = " + TcpPort;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is NsqAddress)
+                return Equals((NsqAddress)obj);
+
+            return false;
+        }
+
+        public bool Equals(NsqAddress other)
+        {
+            return HttpPort == other.HttpPort
+                && TcpPort == other.TcpPort
+                && string.Equals(BroadcastAddress, other.BroadcastAddress, StringComparison.InvariantCultureIgnoreCase)
+                && string.Equals(HostName, other.HostName, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/src/Turbocharged.NSQ/BackoffStrategies.cs
+++ b/src/Turbocharged.NSQ/BackoffStrategies.cs
@@ -6,17 +6,20 @@ using System.Threading.Tasks;
 
 namespace Turbocharged.NSQ
 {
-    interface IBackoffStrategy
+    public interface IBackoffStrategy
     {
         IBackoffLimiter Create();
     }
 
-    interface IBackoffLimiter
+    public interface IBackoffLimiter
     {
         bool ShouldReconnect(out TimeSpan delay);
     }
 
-    class FixedDelayBackoffStrategy : IBackoffStrategy
+    /// <summary>
+    /// Delays a constant amount of time between reconnections.
+    /// </summary>
+    public class FixedDelayBackoffStrategy : IBackoffStrategy
     {
         readonly TimeSpan _delay;
         public FixedDelayBackoffStrategy(TimeSpan delay)
@@ -45,7 +48,11 @@ namespace Turbocharged.NSQ
         }
     }
 
-    class ExponentialBackoffStrategy : IBackoffStrategy
+    /// <summary>
+    /// Delays reconnection with an expontential back-off. For example,
+    /// repeated attempts will delay 1 second, 2 seconds, 4 seconds, etc.
+    /// </summary>
+    public class ExponentialBackoffStrategy : IBackoffStrategy
     {
         readonly TimeSpan _initialDelay;
         readonly TimeSpan _maxDelay;
@@ -79,7 +86,11 @@ namespace Turbocharged.NSQ
         }
     }
 
-    class NoRetryBackoffStrategy : IBackoffStrategy
+    /// <summary>
+    /// Never retries reconnecting. A connection with this back-off strategy
+    /// will simply die when disconnected.
+    /// </summary>
+    public class NoRetryBackoffStrategy : IBackoffStrategy
     {
         public IBackoffLimiter Create()
         {

--- a/src/Turbocharged.NSQ/CommunicationException.cs
+++ b/src/Turbocharged.NSQ/CommunicationException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Turbocharged.NSQ
+{
+    public class CommunicationException : Exception
+    {
+        public CommunicationException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Turbocharged.NSQ/ConsumerOptions.cs
+++ b/src/Turbocharged.NSQ/ConsumerOptions.cs
@@ -45,6 +45,8 @@ namespace Turbocharged.NSQ
         /// </summary>
         public string HostName { get; set; }
 
+        public TimeSpan LookupPeriod { get; set; }
+
         /// <summary>
         /// The maximum number of messages allowed to be in-flight to this consumer. When
         /// connected to several NSQ instances, this number is distributed across the connected
@@ -71,6 +73,7 @@ namespace Turbocharged.NSQ
         const string CHANNEL_KEY = "channel";
         const string CLIENTID_KEY = "clientid";
         const string HOSTNAME_KEY = "hostname";
+        const string LOOKUPPERIOD_KEY = "lookupperiod";
         const string MAXINFLIGHT_KEY = "maxinflight";
         const string RECONNECTIONDELAY_KEY = "reconnectiondelay";
         const string RECONNECTIONMAXDELAY_KEY = "reconnectionmaxdelay";
@@ -87,6 +90,7 @@ namespace Turbocharged.NSQ
 
             ClientId = "Turbocharged.NSQ";
             HostName = Environment.MachineName;
+            LookupPeriod = TimeSpan.FromSeconds(15);
             MaxInFlight = 2500;
             ReconnectionDelay = TimeSpan.FromSeconds(1);
             ReconnectionMaxDelay = TimeSpan.FromSeconds(30);
@@ -129,6 +133,11 @@ namespace Turbocharged.NSQ
             if (parts.Contains(HOSTNAME_KEY))
             {
                 options.HostName = parts[HOSTNAME_KEY].Last();
+            }
+
+            if (parts.Contains(LOOKUPPERIOD_KEY))
+            {
+                options.LookupPeriod = TimeSpan.FromSeconds(int.Parse(parts[LOOKUPPERIOD_KEY].Last()));
             }
 
             if (parts.Contains(MAXINFLIGHT_KEY))

--- a/src/Turbocharged.NSQ/ConsumerOptions.cs
+++ b/src/Turbocharged.NSQ/ConsumerOptions.cs
@@ -48,13 +48,6 @@ namespace Turbocharged.NSQ
         public TimeSpan LookupPeriod { get; set; }
 
         /// <summary>
-        /// The maximum number of messages allowed to be in-flight to this consumer. When
-        /// connected to several NSQ instances, this number is distributed across the connected
-        /// clients evenly.
-        /// </summary>
-        public int MaxInFlight { get; set; }
-
-        /// <summary>
         /// The initial delay before attempting reconnection if the connection to NSQ fails.
         /// By default, the delay will be doubled on each attempt until reconnection, up to
         /// a maximum of <c>ReconnectionMaxDelay</c>.
@@ -74,7 +67,6 @@ namespace Turbocharged.NSQ
         const string CLIENTID_KEY = "clientid";
         const string HOSTNAME_KEY = "hostname";
         const string LOOKUPPERIOD_KEY = "lookupperiod";
-        const string MAXINFLIGHT_KEY = "maxinflight";
         const string RECONNECTIONDELAY_KEY = "reconnectiondelay";
         const string RECONNECTIONMAXDELAY_KEY = "reconnectionmaxdelay";
 
@@ -91,7 +83,6 @@ namespace Turbocharged.NSQ
             ClientId = "Turbocharged.NSQ";
             HostName = Environment.MachineName;
             LookupPeriod = TimeSpan.FromSeconds(15);
-            MaxInFlight = 2500;
             ReconnectionDelay = TimeSpan.FromSeconds(1);
             ReconnectionMaxDelay = TimeSpan.FromSeconds(30);
         }
@@ -138,11 +129,6 @@ namespace Turbocharged.NSQ
             if (parts.Contains(LOOKUPPERIOD_KEY))
             {
                 options.LookupPeriod = TimeSpan.FromSeconds(int.Parse(parts[LOOKUPPERIOD_KEY].Last()));
-            }
-
-            if (parts.Contains(MAXINFLIGHT_KEY))
-            {
-                options.MaxInFlight = int.Parse(parts[MAXINFLIGHT_KEY].Last());
             }
 
             if (parts.Contains(TOPIC_KEY))

--- a/src/Turbocharged.NSQ/DiscoveryEventArgs.cs
+++ b/src/Turbocharged.NSQ/DiscoveryEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Turbocharged.NSQ
+{
+    public class DiscoveryEventArgs : EventArgs
+    {
+        public List<NsqAddress> NsqAddresses { get; private set; }
+
+        public DiscoveryEventArgs(List<NsqAddress> addresses)
+        {
+            NsqAddresses = addresses;
+        }
+    }
+}

--- a/src/Turbocharged.NSQ/NsqConsumer.cs
+++ b/src/Turbocharged.NSQ/NsqConsumer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Turbocharged.NSQ
+{
+    public interface INsqConsumer : IDisposable
+    {
+        Task WriteAsync(MessageBody message);
+        Task SetMaxInFlightAsync(int maxInFlight);
+    }
+
+    public delegate Task MessageHandler(Message message);
+
+    public static class NsqConsumer
+    {
+        public static INsqConsumer Connect(string connectionString, MessageHandler handler)
+        {
+            return Connect(ConsumerOptions.Parse(connectionString), handler);
+        }
+
+        public static INsqConsumer Connect(ConsumerOptions options, MessageHandler handler)
+        {
+            if (options.LookupEndPoints.Any())
+            {
+                throw new NotImplementedException();
+            }
+            else
+            {
+                return NsqTcpConnection.Connect(options.NsqEndPoint, options, handler);
+            }
+        }
+    }
+}

--- a/src/Turbocharged.NSQ/NsqConsumer.cs
+++ b/src/Turbocharged.NSQ/NsqConsumer.cs
@@ -21,15 +21,32 @@ namespace Turbocharged.NSQ
             return Connect(ConsumerOptions.Parse(connectionString), handler);
         }
 
+        public static Task<INsqConsumer> ConnectAndWaitAsync(string connectionString, MessageHandler handler)
+        {
+            return ConnectAndWaitAsync(ConsumerOptions.Parse(connectionString), handler);
+        }
+
         public static INsqConsumer Connect(ConsumerOptions options, MessageHandler handler)
         {
             if (options.LookupEndPoints.Any())
             {
-                throw new NotImplementedException();
+                return NsqLookupConsumer.Connect(options, handler);
             }
             else
             {
                 return NsqTcpConnection.Connect(options.NsqEndPoint, options, handler);
+            }
+        }
+
+        public static async Task<INsqConsumer> ConnectAndWaitAsync(ConsumerOptions options, MessageHandler handler)
+        {
+            if (options.LookupEndPoints.Any())
+            {
+                return await NsqLookupConsumer.ConnectAndWaitAsync(options, handler).ConfigureAwait(false);
+            }
+            else
+            {
+                return await NsqTcpConnection.ConnectAndWaitAsync(options.NsqEndPoint, options, handler).ConfigureAwait(false);
             }
         }
     }

--- a/src/Turbocharged.NSQ/NsqLookup.cs
+++ b/src/Turbocharged.NSQ/NsqLookup.cs
@@ -43,13 +43,11 @@ namespace Turbocharged.NSQ
             {
                 return
                     ((JArray)response["data"]["producers"])
-                    .Select(producer => new NsqAddress
-                    {
-                        BroadcastAddress = (string)producer["broadcast_address"],
-                        HostName = (string)producer["hostname"],
-                        HttpPort = (int)producer["http_port"],
-                        TcpPort = (int)producer["tcp_port"],
-                    })
+                    .Select(producer => new NsqAddress(
+                            (string)producer["broadcast_address"],
+                            (string)producer["hostname"],
+                            (int)producer["tcp_port"],
+                            (int)producer["http_port"]))
                     .ToList();
             });
         }
@@ -90,13 +88,11 @@ namespace Turbocharged.NSQ
             {
                 return
                     ((JArray)response["data"]["producers"])
-                    .Select(producer => new NsqAddress
-                    {
-                        BroadcastAddress = (string)producer["broadcast_address"],
-                        HostName = (string)producer["hostname"],
-                        HttpPort = (int)producer["http_port"],
-                        TcpPort = (int)producer["tcp_port"],
-                    })
+                    .Select(producer => new NsqAddress(
+                            (string)producer["broadcast_address"],
+                            (string)producer["hostname"],
+                            (int)producer["tcp_port"],
+                            (int)producer["http_port"]))
                     .ToList();
             });
         }

--- a/src/Turbocharged.NSQ/NsqLookupConsumer.cs
+++ b/src/Turbocharged.NSQ/NsqLookupConsumer.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Turbocharged.NSQ
+{
+    public class NsqLookupConsumer : INsqConsumer
+    {
+        readonly Dictionary<DnsEndPoint, NsqTcpConnection> _connections = new Dictionary<DnsEndPoint, NsqTcpConnection>();
+        readonly List<NsqLookup> _lookupServers = new List<NsqLookup>();
+        readonly System.Threading.Timer _lookupTimer;
+        readonly ConsumerOptions _options;
+        readonly MessageHandler _handler;
+        readonly Task _firstConnectionTask;
+
+        bool firstDiscoveryCycle = true;
+
+        // No need to ever reconnect, we'll reconnect on the next lookup cycle
+        static readonly NoRetryBackoffStrategy _noRetryBackoff = new NoRetryBackoffStrategy();
+
+        public EventHandler<InternalMessageEventArgs> InternalMessages;
+        public EventHandler<DiscoveryEventArgs> DiscoveryCompleted;
+
+        internal void OnDiscoveryCompleted(List<NsqAddress> addresses)
+        {
+            var handler = DiscoveryCompleted;
+            if (handler != null)
+            {
+                handler(this, new DiscoveryEventArgs(addresses));
+            }
+        }
+
+        internal void OnInternalMessage(string format, object arg0)
+        {
+            var handler = InternalMessages;
+            if (handler != null)
+            {
+                handler(this, new InternalMessageEventArgs(string.Format(format, arg0)));
+            }
+        }
+
+        internal void OnInternalMessage(string format, params object[] args)
+        {
+            var handler = InternalMessages;
+            if (handler != null)
+            {
+                handler(this, new InternalMessageEventArgs(string.Format(format, args)));
+            }
+        }
+
+        NsqLookupConsumer(ConsumerOptions options, MessageHandler handler)
+        {
+            _options = options;
+            _handler = handler;
+
+            foreach (var lookupEndPoint in options.LookupEndPoints)
+            {
+                _lookupServers.Add(new NsqLookup(lookupEndPoint.Host, lookupEndPoint.Port));
+            }
+
+            var tcs = new TaskCompletionSource<bool>();
+            _firstConnectionTask = tcs.Task;
+
+            // Start the lookup timer
+            _lookupTimer = new System.Threading.Timer(LookupTask, tcs, TimeSpan.Zero, _options.LookupPeriod);
+        }
+
+        public static async Task<NsqLookupConsumer> ConnectAndWaitAsync(string connectionString, MessageHandler handler)
+        {
+            var consumer = Connect(connectionString, handler);
+            await consumer._firstConnectionTask.ConfigureAwait(false);
+            return consumer;
+        }
+
+        public static async Task<NsqLookupConsumer> ConnectAndWaitAsync(ConsumerOptions options, MessageHandler handler)
+        {
+            var consumer = Connect(options, handler);
+            await consumer._firstConnectionTask.ConfigureAwait(false);
+            return consumer;
+        }
+
+        public static NsqLookupConsumer Connect(string connectionString, MessageHandler handler)
+        {
+            return Connect(ConsumerOptions.Parse(connectionString), handler);
+        }
+
+        public static NsqLookupConsumer Connect(ConsumerOptions options, MessageHandler handler)
+        {
+            var consumer = new NsqLookupConsumer(options, handler);
+            return consumer;
+        }
+
+        void LookupTask(object firstConnection)
+        {
+            var firstConnectionTcs = (TaskCompletionSource<bool>)firstConnection;
+
+            OnInternalMessage("Begin lookup cycle");
+            int beginningCount, endingCount,
+                added = 0, removed = 0;
+
+            lock (_connections)
+            {
+                var tasks = _lookupServers.Select(server => server.LookupAsync(_options.Topic)).ToList();
+                var delay = Task.Delay(5000);
+                Task.WhenAny(Task.WhenAll(tasks), delay).Wait();
+
+                var nsqAddresses =
+                    tasks.Where(t => t.Status == TaskStatus.RanToCompletion)
+                    .SelectMany(t => t.Result)
+                    .Distinct()
+                    .ToList();
+
+                var servers =
+                    nsqAddresses
+                    .Select(add => new DnsEndPoint(add.BroadcastAddress, add.TcpPort))
+                    .ToList();
+
+                var currentEndPoints = _connections.Keys;
+                var newEndPoints = servers.Except(currentEndPoints);
+                var removedEndPoints = currentEndPoints.Except(servers);
+
+                foreach (var endPoint in removedEndPoints)
+                {
+                    var connection = _connections[endPoint];
+                    _connections.Remove(endPoint);
+                    connection.Dispose();
+                    removed++;
+                }
+
+                foreach (var endPoint in newEndPoints)
+                {
+                    if (!_connections.ContainsKey(endPoint))
+                    {
+                        var connection = NsqTcpConnection.Connect(endPoint, _options, _noRetryBackoff, _handler);
+                        connection.InternalMessages +=
+                            ((EventHandler<InternalMessageEventArgs>)((sender, e) => OnInternalMessage("{0}: {1}", endPoint, e.Message)));
+                        _connections[endPoint] = connection;
+                        added++;
+                    }
+                }
+
+                beginningCount = currentEndPoints.Count;
+                endingCount = _connections.Count;
+
+                OnDiscoveryCompleted(nsqAddresses.ToList());
+
+                if (firstDiscoveryCycle)
+                {
+                    firstConnectionTcs.TrySetResult(true);
+                    firstDiscoveryCycle = false;
+                }
+            }
+
+            OnInternalMessage("End lookup cycle. BeginningCount = {0}, EndingCount = {1}, Added = {2}, Removed = {3}", beginningCount, endingCount, added, removed);
+        }
+
+        public async Task WriteAsync(MessageBody message)
+        {
+            await _firstConnectionTask.ConfigureAwait(false);
+
+            List<NsqTcpConnection> connections;
+            lock (_connections)
+            {
+                connections = _connections.Values.ToList();
+            }
+
+            if (connections.Count == 0)
+                throw new CommunicationException("No NSQ connections are available");
+
+            foreach (var thing in connections)
+            {
+                try
+                {
+                    await thing.WriteAsync(message).ConfigureAwait(false);
+                    return;
+                }
+                catch
+                {
+                    continue;
+                }
+            }
+
+            throw new CommunicationException("Write failed against all NSQ connections");
+        }
+
+        public async Task SetMaxInFlightAsync(int maxInFlight)
+        {
+            await _firstConnectionTask.ConfigureAwait(false);
+
+            List<NsqTcpConnection> connections;
+            lock (_connections)
+            {
+                connections = _connections.Values.ToList();
+            }
+
+            int maxInFlightPerServer = maxInFlight / connections.Count;
+            int leftover = maxInFlight - (maxInFlightPerServer * connections.Count);
+
+            var tasks = new List<Task>(connections.Count);
+            foreach (var connection in connections)
+            {
+                int max = maxInFlightPerServer;
+                if (leftover > 0) max += leftover--;
+                tasks.Add(connection.SetMaxInFlightAsync(max));
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+
+        public void Dispose()
+        {
+            lock (_connections)
+            {
+                _lookupTimer.Dispose();
+
+                foreach (var connection in _connections.Values)
+                    connection.Dispose();
+            }
+        }
+    }
+}

--- a/src/Turbocharged.NSQ/NsqLookupConsumer.cs
+++ b/src/Turbocharged.NSQ/NsqLookupConsumer.cs
@@ -16,7 +16,7 @@ namespace Turbocharged.NSQ
         readonly MessageHandler _handler;
         readonly Task _firstConnectionTask;
 
-        bool firstDiscoveryCycle = true;
+        bool _firstDiscoveryCycle = true;
         int _maxInFlight = 0;
 
         // No need to ever reconnect, we'll reconnect on the next lookup cycle
@@ -148,10 +148,10 @@ namespace Turbocharged.NSQ
 
                 OnDiscoveryCompleted(nsqAddresses.ToList());
 
-                if (firstDiscoveryCycle)
+                if (_firstDiscoveryCycle)
                 {
                     firstConnectionTcs.TrySetResult(true);
-                    firstDiscoveryCycle = false;
+                    _firstDiscoveryCycle = false;
                 }
             }
 

--- a/src/Turbocharged.NSQ/NsqTcpConnection.cs
+++ b/src/Turbocharged.NSQ/NsqTcpConnection.cs
@@ -25,7 +25,7 @@ namespace Turbocharged.NSQ
 
         readonly CancellationTokenSource _connectionClosedSource;
         readonly ConsumerOptions _options;
-        readonly DnsEndPoint _endPoint;
+        readonly internal DnsEndPoint _endPoint;
         readonly MessageHandler _messageHandler;
         readonly IBackoffStrategy _backoffStrategy;
         readonly Thread _workerThread;

--- a/src/Turbocharged.NSQ/TopicAndChannel.cs
+++ b/src/Turbocharged.NSQ/TopicAndChannel.cs
@@ -10,29 +10,30 @@ namespace Turbocharged.NSQ
     /// A topic name in NSQ. Topics should represent a type of message,
     /// for example, "new-users" or "order-updated".
     /// </summary>
-    public class Topic
+    public struct Topic
     {
-        readonly string _topic;
+        public string Name { get; private set; }
 
         public Topic(string topic)
+            : this()
         {
             if (topic == null) throw new ArgumentNullException("topic");
-            _topic = topic;
+            Name = topic;
         }
 
         public override string ToString()
         {
-            return _topic;
+            return Name;
         }
 
         internal byte[] ToUTF8()
         {
-            return Encoding.UTF8.GetBytes(_topic);
+            return Encoding.UTF8.GetBytes(Name);
         }
 
         public static implicit operator string(Topic topic)
         {
-            return topic._topic;
+            return topic.Name;
         }
 
         public static implicit operator Topic(string topic)
@@ -45,29 +46,30 @@ namespace Turbocharged.NSQ
     /// A channel name in NSQ. Channels should represent the action of a consumer,
     /// for example, "send_email" or "create_database_record".
     /// </summary>
-    public class Channel
+    public struct Channel
     {
-        readonly string _channel;
+        public string Name { get; private set; }
 
         public Channel(string channel)
+            : this()
         {
             if (channel == null) throw new ArgumentNullException("channel");
-            _channel = channel;
+            Name = channel;
         }
 
         public override string ToString()
         {
-            return _channel;
+            return Name;
         }
 
         internal byte[] ToUTF8()
         {
-            return Encoding.UTF8.GetBytes(_channel);
+            return Encoding.UTF8.GetBytes(Name);
         }
 
         public static implicit operator string(Channel channel)
         {
-            return channel._channel;
+            return channel.Name;
         }
 
         public static implicit operator Channel(string channel)

--- a/src/Turbocharged.NSQ/Turbocharged.NSQ.csproj
+++ b/src/Turbocharged.NSQ/Turbocharged.NSQ.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Message.cs" />
     <Compile Include="FrameReader.cs" />
     <Compile Include="MessageBody.cs" />
+    <Compile Include="NsqConsumer.cs" />
     <Compile Include="NsqLookup.cs" />
     <Compile Include="Addresses.cs" />
     <Compile Include="Commands\Nop.cs" />

--- a/src/Turbocharged.NSQ/Turbocharged.NSQ.csproj
+++ b/src/Turbocharged.NSQ/Turbocharged.NSQ.csproj
@@ -48,10 +48,12 @@
     <Compile Include="BackoffStrategies.cs" />
     <Compile Include="Commands\ByteArrays.cs" />
     <Compile Include="Commands\Finish.cs" />
+    <Compile Include="CommunicationException.cs" />
     <Compile Include="Frame.cs" />
     <Compile Include="Commands\ICommand.cs" />
     <Compile Include="ConsumerOptions.cs" />
     <Compile Include="Commands\Identify.cs" />
+    <Compile Include="DiscoveryEventArgs.cs" />
     <Compile Include="InternalMessageEventArgs.cs" />
     <Compile Include="Message.cs" />
     <Compile Include="FrameReader.cs" />
@@ -62,6 +64,7 @@
     <Compile Include="Commands\Nop.cs" />
     <Compile Include="Commands\Ready.cs" />
     <Compile Include="Commands\Subscribe.cs" />
+    <Compile Include="NsqLookupConsumer.cs" />
     <Compile Include="NsqProducer.cs" />
     <Compile Include="NsqStatistics.cs" />
     <Compile Include="System\Disposable.cs" />


### PR DESCRIPTION
There should be two types of consumers:
- **Type A**: One which connects to an explicit nsqd instance.
- **Type B**: One which connects to 1+ nsqlookupd instances and uses lookup to find relevant nsqd instances

A user of this library should be able to switch between the two via connection string. That is, the connection string should specify whether a client should be type A or type B. No code change should be necessary.
